### PR TITLE
Align with the wording in the final standard

### DIFF
--- a/remoteid/canonical.yaml
+++ b/remoteid/canonical.yaml
@@ -1373,7 +1373,6 @@ components:
             Subscription is created, modified, or deleted.  Must implement PUT and
             DELETE according to the `/uss/identification_service_areas/{id}` path
             API.
-          example: https://example.com/identification_service_areas
     PutSubscriptionResponse:
       description: Response for a request to create or update a subscription.
       required:
@@ -1428,7 +1427,7 @@ components:
           $ref: '#/components/schemas/RIDAuthData'
         serial_number:
           description: Can be specified when no registration ID exists and required
-            by law in a region. This is expressed in the ANSI/CTA-2063 Physical Serial
+            by law in a region. This is expressed in the ANSI/CTA-2063-A Physical Serial
             Number format.
           type: string
           example: INTCJ123-4567-890
@@ -1713,11 +1712,11 @@ components:
       description: |-
         Type of aircraft for the purposes of remote ID.
 
-        `VTOL` is a fixed wing aircraft that can take off vertically.  `Rotocraft` includes multirotor.
+        `VTOL` is a fixed wing aircraft that can take off vertically.  `Helicopter` includes multirotor.
       enum:
       - NotDeclared
       - Aeroplane
-      - Rotorcraft
+      - Helicopter
       - Gyroplane
       - VTOL
       - Ornithopter


### PR DESCRIPTION
I did a source compare of the text in the final ASTM standard against the text in the canonical.yaml.

It looks like you have provided the text from the fix_mistakes branch for the final version. On top of that there were a few additional changes done based on input from me.

Would it be possible to merge in the fix_mistakes branch to master and on top of that merge in the final_standards_corrections branch as well to master?

Just to ensure that there is an electronic version of the text available that matches 100% what went in the standards document. Copying the text out from the pdf document causes all kinds of formatting problems. Fetching it here from Github provides a clean file.